### PR TITLE
Initial / start of implementation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every week
+      interval: "weekly"

--- a/.github/workflows/include.yml
+++ b/.github/workflows/include.yml
@@ -1,0 +1,32 @@
+# Remember to change/update `description` below when copying
+# this include
+name: "Shared cli/server fortio workflows"
+on:
+    push:
+      branches: [ main ]
+      tags:
+        # so a vX.Y.Z-test1 doesn't trigger build
+        - 'v[0-9]+.[0-9]+.[0-9]+'
+        - 'v[0-9]+.[0-9]+.[0-9]+-pre*'
+    pull_request:
+      branches: [ main ]
+
+jobs:
+    call-gochecks:
+        uses: fortio/workflows/.github/workflows/gochecks.yml@main
+    call-codecov:
+        uses: fortio/workflows/.github/workflows/codecov.yml@main
+    call-codeql:
+        uses: fortio/workflows/.github/workflows/codeql-analysis.yml@main
+        permissions:
+            actions: read
+            contents: read
+            security-events: write
+    call-releaser:
+        uses: fortio/workflows/.github/workflows/releaser.yml@main
+        with:
+            description: "Fix line too long lll linter errors"
+        secrets:
+            GH_PAT: ${{ secrets.GH_PAT }}
+            DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
+            DOCKER_USER: ${{ secrets.DOCKER_USER }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.lll
 *.bak
 test.txt
+lll-fixer
 # If you prefer the allow list template instead of the deny list, see community template:
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 #

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.golangci.yml
+*.lll
 # If you prefer the allow list template instead of the deny list, see community template:
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 #

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .golangci.yml
+.goreleaser.yaml
 *.lll
 *.bak
 # If you prefer the allow list template instead of the deny list, see community template:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .golangci.yml
 *.lll
+*.bak
 # If you prefer the allow list template instead of the deny list, see community template:
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 #

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .goreleaser.yaml
 *.lll
 *.bak
+test.txt
 # If you prefer the allow list template instead of the deny list, see community template:
 # https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM scratch
+COPY lll-fixer /usr/bin/lll-fixer
+ENTRYPOINT ["/usr/bin/lll-fixer"]
+CMD ["help"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+
+manual-test:
+	cp lll_fixer.go test.txt && go run . -loglevel debug test.txt ; colordiff -u lll_fixer.go test.txt
+
+
+.PHONY: manual-test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # lll-fixer
 Fix lll (line length limit) lines too long linter errors in go files
 
+## Installation
+
+From source
+```
+go install github.com/ldemailly/lll-fixer@latest
+```
+
+Or see the numerous binaries in https://github.com/ldemailly/lll-fixer/releases
+
+Or docker `fortio/lll-fixer:latest`
+
+Or brew `brew install fortio/tap/lll-fixer`
+
+(I manage the fortio org and usually put everything there but this one is a bit unrelated so for now it is hosted here in `ldemailly` yet uses fortio's org for docker and brew)
+
+## Example
+
 Test on itself:
 ```
 $ go run . lll_fixer.go

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # lll-fixer
 Fix lll (line length limit) lines too long linter errors in go files
+
+Currently weird bug with `-len 79`: (2 new lines somehow)
+
+```diff
+21:02:56 main lll-fixer/$ colordiff -u lll_fixer.go lll_fixer.go.lll
+--- lll_fixer.go	2024-03-20 21:02:46.473102471 -0700
++++ lll_fixer.go.lll	2024-03-20 21:02:56.382460319 -0700
+@@ -24,7 +24,9 @@
+ 	}
+ }
+
+-// process modifies the file filename to split long comments at maxlen. making this line longer than 80 characters to test the lll fixer itself. fun no?
++// process modifies the file filename to split long comments at maxlen. making
++//
++//	this line longer than 80 characters to test the lll fixer itself. fun no?
+ func process(filename string, maxlen int) {
+ 	// Parse the Go file
+ 	fset := token.NewFileSet()
+```

--- a/README.md
+++ b/README.md
@@ -1,21 +1,2 @@
 # lll-fixer
 Fix lll (line length limit) lines too long linter errors in go files
-
-Currently weird bug with `-len 79`: (2 new lines somehow)
-
-```diff
-21:02:56 main lll-fixer/$ colordiff -u lll_fixer.go lll_fixer.go.lll
---- lll_fixer.go	2024-03-20 21:02:46.473102471 -0700
-+++ lll_fixer.go.lll	2024-03-20 21:02:56.382460319 -0700
-@@ -24,7 +24,9 @@
- 	}
- }
-
--// process modifies the file filename to split long comments at maxlen. making this line longer than 80 characters to test the lll fixer itself. fun no?
-+// process modifies the file filename to split long comments at maxlen. making
-+//
-+//	this line longer than 80 characters to test the lll fixer itself. fun no?
- func process(filename string, maxlen int) {
- 	// Parse the Go file
- 	fset := token.NewFileSet()
-```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # lll-fixer
 Fix lll (line length limit) lines too long linter errors in go files
+
+Test on itself:
+```
+$ go run . lll_fixer.go
+```
+
+```diff
+diff --git a/lll_fixer.go b/lll_fixer.go
+index c5edf97..30452c3 100644
+--- a/lll_fixer.go
++++ b/lll_fixer.go
+@@ -43,7 +43,8 @@ func main() {
+        }
+ }
+
+-// process modifies the file filename to split long comments at maxlen. making this line longer than 80 characters to test.
++// process modifies the file filename to split long comments at maxlen. making
++// this line longer than 80 characters to test.
+ func process(fset *token.FileSet, filename string, maxlen int) string {
+        log.Infof("Processing file %q", filename)
+        // Parse the Go file
+```

--- a/bug_repro/bug.go
+++ b/bug_repro/bug.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"fmt"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"os"
+)
+
+/*
+ * multi line comment
+ */
+func main() {
+	code := `package main
+/*
+ * multi line comment
+ */
+func main() {
+}
+`
+	fmt.Println("---input---")
+	fmt.Println(code)
+	fmt.Println("---processing---")
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, "bug.go", code, parser.ParseComments)
+	if err != nil {
+		panic(err)
+	}
+	for _, cg := range node.Comments {
+		for _, c := range cg.List {
+			fmt.Printf("Found comment     %q\n", c.Text)
+			if len(c.Text) > 10 {
+				fmt.Printf("Splitting comment %q\n", c.Text)
+				c.Text = c.Text[:10] + "\n * " + c.Text[10:]
+				fmt.Printf("into ->           %q\n", c.Text)
+			}
+		}
+	}
+	fmt.Println("---result---")
+	if err := format.Node(os.Stdout, fset, node); err != nil {
+		panic(err)
+	}
+}

--- a/bug_repro/bug.go
+++ b/bug_repro/bug.go
@@ -9,16 +9,16 @@ import (
 )
 
 /*
- * multi line comment
+ * multi line comment.
  */
 func main() {
 	code := `package main
+
 /*
- * multi line comment
+ * multi line comment.
  */
 func main() {
-}
-`
+}`
 	fmt.Println("---input---")
 	fmt.Println(code)
 	fmt.Println("---processing---")
@@ -30,9 +30,9 @@ func main() {
 	for _, cg := range node.Comments {
 		for _, c := range cg.List {
 			fmt.Printf("Found comment     %q\n", c.Text)
-			if len(c.Text) > 10 {
+			if len(c.Text) > 11 {
 				fmt.Printf("Splitting comment %q\n", c.Text)
-				c.Text = c.Text[:10] + "\n * " + c.Text[10:]
+				c.Text = c.Text[:11] + "\n *" + c.Text[11:]
 				fmt.Printf("into ->           %q\n", c.Text)
 			}
 		}

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,12 @@ module github.com/ldemailly/lll-fixer
 
 go 1.21
 
-require fortio.org/cli v1.5.1
+require (
+	fortio.org/cli v1.5.1
+	fortio.org/log v1.12.0
+)
 
 require (
-	fortio.org/log v1.12.0 // indirect
 	fortio.org/struct2env v0.4.0 // indirect
 	fortio.org/version v1.0.3 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module github.com/ldemailly/lll-fixer
+
+go 1.21
+
+require fortio.org/cli v1.5.1
+
+require (
+	fortio.org/log v1.12.0 // indirect
+	fortio.org/struct2env v0.4.0 // indirect
+	fortio.org/version v1.0.3 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,8 @@
+fortio.org/cli v1.5.1 h1:lqPvkxRVSajsVwLfblaN62BPAICPp05Oab+yjRvI3DU=
+fortio.org/cli v1.5.1/go.mod h1:Tp7AypudP1mJomTUN/J/vlOTlZDWTMsok09MMyA99ow=
+fortio.org/log v1.12.0 h1:5Yg4pL9Pp0jcWeJYixm2xikMCldVaSDMgDFDmQJZfho=
+fortio.org/log v1.12.0/go.mod h1:1tMBG/Elr6YqjmJCWiejJp2FPvXg7/9UAN0Rfpkyt1o=
+fortio.org/struct2env v0.4.0 h1:k5alSOTf3YHiB3MuacjDHQ3YhVWvNZ95ZP/a6MqvyLo=
+fortio.org/struct2env v0.4.0/go.mod h1:lENUe70UwA1zDUCX+8AsO663QCFqYaprk5lnPhjD410=
+fortio.org/version v1.0.3 h1:5gJ3plj6isAOMq52cI5ifo4cC+QHmJF76Wevc5Cp4x0=
+fortio.org/version v1.0.3/go.mod h1:2JQp9Ax+tm6QKiGuzR5nJY63kFeANcgrZ0osoQFDVm0=

--- a/lll_fixer.go
+++ b/lll_fixer.go
@@ -70,7 +70,7 @@ func splitAtWord(s string, maxlen int) string {
 	var mid string
 	switch {
 	case strings.HasPrefix(lead, "/* "):
-		mid = "\n/* "
+		mid = "\n * "
 	case strings.HasPrefix(lead, " * "):
 		mid = "\n * "
 	case strings.HasPrefix(lead, "// "):

--- a/lll_fixer.go
+++ b/lll_fixer.go
@@ -16,6 +16,7 @@ import (
 
 func main() {
 	maxlen := flag.Int("len", 79, "max line length")
+	funmpt := flag.Bool("fumpt", false, "run gofumpt on the modified file")
 	cli.MinArgs = 1
 	cli.MaxArgs = -1
 	cli.ArgsHelp = "filenames..."
@@ -34,12 +35,14 @@ func main() {
 		}
 		log.Infof("Renamed file %q to %q", newname, filename)
 		// Run gofumpt on the modified file
-		cmd := exec.Command("gofumpt", "-w", filename)
-		if err := cmd.Run(); err != nil {
-			log.Errf("Error running gofumpt: %v", err)
-			return
+		if *funmpt {
+			cmd := exec.Command("gofumpt", "-w", filename)
+			if err := cmd.Run(); err != nil {
+				log.Errf("Error running gofumpt: %v", err)
+				return
+			}
+			log.Infof("Ran gofumpt on the now modified file %q", filename)
 		}
-		log.Infof("Ran gofumpt on the now modified file %q", filename)
 	}
 }
 

--- a/lll_fixer.go
+++ b/lll_fixer.go
@@ -25,7 +25,7 @@ func main() {
 	}
 }
 
-// process modifies the file filename to split long comments at maxlen. making this line longer than 80 characters to test the lll fixer itself. fun no?
+// process modifies the file filename to split long comments at maxlen. making this line longer than 80 characters to test.
 func process(filename string, maxlen int) {
 	// Parse the Go file
 	fset := token.NewFileSet()

--- a/lll_fixer.go
+++ b/lll_fixer.go
@@ -64,7 +64,8 @@ func splitAtWord(s string, maxlen int) string {
 	}
 	// find the last space before maxlen
 	i := strings.LastIndex(s[:maxlen], " ")
-	if i == -1 {
+	nospace := (i == -1)
+	if nospace {
 		// no space found, split at maxlen
 		log.Warnf("No word/space found in first %d characters for %q", maxlen, s)
 		i = maxlen
@@ -81,6 +82,9 @@ func splitAtWord(s string, maxlen int) string {
 		mid = "\n// "
 	case strings.HasPrefix(lead, "\""):
 		mid = "\" +\n\t\"" // for string literals splitting
+		if !nospace {
+			mid += " "
+		}
 	default:
 		log.Warnf("Unexpected lead %q", lead)
 		mid = "\n "

--- a/lll_fixer.go
+++ b/lll_fixer.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"flag"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"os"
+
+	"fortio.org/cli"
+	"fortio.org/log"
+)
+
+func main() {
+	maxlen := flag.Int("len", 79, "max line length") // 78 or 80 or 132 works but... somehow 79 is creating 2 new lines(!)
+	cli.MinArgs = 1
+	cli.MaxArgs = -1
+	cli.ArgsHelp = "filenames..."
+	cli.Main()
+	for _, filename := range flag.Args() {
+		process(filename, *maxlen)
+		// Run gofumpt on the modified file
+	}
+}
+
+// process modifies the file filename to split long comments at maxlen. making this line longer than 80 characters to test the lll fixer itself. fun no?
+func process(filename string, maxlen int) {
+	// Parse the Go file
+	fset := token.NewFileSet()
+	log.Infof("Processing file %q", filename)
+	node, err := parser.ParseFile(fset, filename, nil, parser.ParseComments)
+	if err != nil {
+		log.Errf("Error parsing %q: %v", filename, err)
+		return
+	}
+
+	// Traverse and modify the AST
+	ast.Inspect(node, func(n ast.Node) bool {
+		// Split long comments
+		if c, ok := n.(*ast.Comment); ok {
+			if len(c.Text) > maxlen {
+				c.Text = c.Text[:maxlen-1] + "\n// " + c.Text[maxlen-1:]
+			}
+		}
+		return true
+	})
+
+	// Generate the modified code
+	newname := filename + ".lll"
+	f, err := os.Create(newname)
+	if err != nil {
+		log.Errf("Error creating modified file %q: %v", newname, err)
+	}
+	defer f.Close()
+	if err := format.Node(f, fset, node); err != nil {
+		log.Errf("Error outputting modified file: %v", err)
+	}
+	log.Infof("Modified file written to %q", newname)
+}

--- a/lll_fixer.go
+++ b/lll_fixer.go
@@ -20,6 +20,10 @@ func main() {
 	cli.MinArgs = 1
 	cli.MaxArgs = -1
 	cli.ArgsHelp = "filenames..."
+	if false {
+		// just to test literal string split
+		cli.ArgsHelp = "this is a very a long string literal to test the split of long strings inside code"
+	}
 	cli.Main()
 	fset := token.NewFileSet()
 	for _, filename := range flag.Args() {
@@ -75,6 +79,8 @@ func splitAtWord(s string, maxlen int) string {
 		mid = "\n * "
 	case strings.HasPrefix(lead, "// "):
 		mid = "\n// "
+	case strings.HasPrefix(lead, "\""):
+		mid = "\" +\n\t\"" // for string literals splitting
 	default:
 		log.Warnf("Unexpected lead %q", lead)
 		mid = "\n "
@@ -83,11 +89,18 @@ func splitAtWord(s string, maxlen int) string {
 	return strings.TrimSpace(s[:i]) + mid + strings.TrimLeft(s[i:], " ")
 }
 
+// TODO process other nodes (and also maybe split leftmost position in line vs length of comment/literal
+// which could be far to the right)
+
 func processNode(n ast.Node, maxlen int) bool {
 	if false {
 		log.Debugf("Found node: %+v to shrink to %d", n, maxlen)
 	}
-	// process the other lines (not just comments)
+	// process string literals
+	if lit, ok := n.(*ast.BasicLit); ok && lit.Kind == token.STRING {
+		lit.Value = splitAtWord(lit.Value, maxlen)
+	}
+	// more nodes...
 	return true
 }
 

--- a/lll_fixer.go
+++ b/lll_fixer.go
@@ -7,6 +7,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"strings"
 
 	"fortio.org/cli"
 	"fortio.org/log"
@@ -40,7 +41,9 @@ func process(filename string, maxlen int) {
 		// Split long comments
 		if c, ok := n.(*ast.Comment); ok {
 			if len(c.Text) > maxlen {
-				c.Text = c.Text[:maxlen-1] + "\n// " + c.Text[maxlen-1:]
+				log.LogVf("Splitting comment %q", c.Text)
+				c.Text = strings.TrimSpace(c.Text[:maxlen-1]) + "\n// " + strings.TrimSpace(c.Text[maxlen-1:])
+				log.LogVf("-> %q", c.Text)
 			}
 		}
 		return true

--- a/lll_fixer_test.go
+++ b/lll_fixer_test.go
@@ -34,6 +34,10 @@ func TestSplitAtWord(t *testing.T) {
 		{"// abc 1234567890", "// abc\n// 1234567890"},
 		{"/* abc   1234567890 */", "/* abc\n * 1234567890 */"},
 		{"/*\n * abc   1234567890\n*/", "/*\n * abc\n * 1234567890\n*/"},
+		{`"abc 1234567890"`, `"abc" +
+	" 1234567890"`},
+		{`"123456789ABC"`, `"123456789" +
+	"ABC"`},
 	}
 	// loop through the tests
 	for _, test := range tests {

--- a/lll_fixer_test.go
+++ b/lll_fixer_test.go
@@ -19,7 +19,29 @@ func TestLineLead(t *testing.T) {
 		actual := lineLead(test.input)
 		// compare the actual vs expected
 		if actual != test.expected {
-			t.Errorf("Test failed! Expected: %v, Actual: %v", test.expected, actual)
+			t.Errorf("Test failed! Expected: %q, Actual: %q", test.expected, actual)
 		}
 	}
+}
+
+func TestSplitAtWord(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Hello", "Hello"},
+		{"123456789ABC", "123456789A\n BC"},
+		{"// abc 1234567890", "// abc\n// 1234567890"},
+		{"/* abc   1234567890 */", "/* abc\n * 1234567890 */"},
+		{"/*\n * abc   1234567890\n*/", "/*\n * abc\n * 1234567890\n*/"},
+	}
+	// loop through the tests
+	for _, test := range tests {
+		actual := splitAtWord(test.input, 10)
+		// compare the actual vs expected
+		if actual != test.expected {
+			t.Errorf("Test failed! Expected: %q, Actual: %q", test.expected, actual)
+		}
+	}
+
 }

--- a/lll_fixer_test.go
+++ b/lll_fixer_test.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestLineLead(t *testing.T) {
+	// tests input vs actual struct:
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"Hello", "Hello"},
+		{"\nHello", "Hello"},
+		{"abc\nxyz\nTest", "Test"},
+	}
+	// loop through the tests
+	for _, test := range tests {
+		actual := lineLead(test.input)
+		// compare the actual vs expected
+		if actual != test.expected {
+			t.Errorf("Test failed! Expected: %v, Actual: %v", test.expected, actual)
+		}
+	}
+}

--- a/lll_fixer_test.go
+++ b/lll_fixer_test.go
@@ -43,5 +43,4 @@ func TestSplitAtWord(t *testing.T) {
 			t.Errorf("Test failed! Expected: %q, Actual: %q", test.expected, actual)
 		}
 	}
-
 }

--- a/lll_fixer_test.go
+++ b/lll_fixer_test.go
@@ -10,9 +10,9 @@ func TestLineLead(t *testing.T) {
 		input    string
 		expected string
 	}{
-		{"Hello", "Hello"},
-		{"\nHello", "Hello"},
-		{"abc\nxyz\nTest", "Test"},
+		{"Hello", "Hel"},
+		{"\nHello", "Hel"},
+		{"abc\nxyz\nTest", "Tes"},
 	}
 	// loop through the tests
 	for _, test := range tests {


### PR DESCRIPTION
- [x] basic structure
- [x] fix issue with leading whitespace in (split) comments
- [x] handle in place changes (rename original to .bak) as well as gofumpt
- [x] better/smart (word) cut for comments
- [x] handle /* and not just //
- [ ] issue with disappearing new line before function after */ (see `make test`) https://github.com/golang/go/issues/66439
- [x] handle comments not just at top level
- [x] handle string literals (which is most of the issues in https://github.com/fortio/slack-proxy/pull/49)
- [ ] handle that a literal or comment maybe below the `-len` yet making a line in total > len (because of right indentation)
- [ ] cut more lines like function signatures